### PR TITLE
Removed cadcTV's video information.

### DIFF
--- a/corruptors/vinesauce-rom-corruptor.md
+++ b/corruptors/vinesauce-rom-corruptor.md
@@ -188,5 +188,3 @@ TODO
 ###### YouTube user FZERO has a simple guide showing the basics of the corruptor.
 
 {% youtube %}yTGgPwivxak{% endyoutube %}
-
-###### cadcTV has a two part tutorial on using the corruptor, the first part explains the basic usage of the corruptor.


### PR DESCRIPTION
YouTube URL pointing to cadcTV's original tutorial is broken.  Cannot locate the original video, thus removing the broken link.